### PR TITLE
State that only Declarative pipeline is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This extension validates Jenkinsfiles by sending them to the Pipeline Linter of 
 ## Features
 
 - Validate Jenkinsfiles from wihin vscode.
+- Supports declarative pipeline only.
 
 ## Examples
 


### PR DESCRIPTION
I know this is probably common knowledge, but I spent quite some time setting this plugin and jenkins up, only to find out it does not work for scripted pipelines.