### PR TITLE
fix requestCrumb(...) option array missing 'headers: {}' for 'options…

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,7 +49,8 @@ function requestCrumb(fs: any, request: any, url: string, crumbUrl: string, user
     let options: any = {
         method: 'GET',
         url: crumbUrl,
-        strictSSL: strictssl
+        strictSSL: strictssl,
+        headers: {}
     };
 
     if (user !== undefined && user.length > 0) {


### PR DESCRIPTION
Hi,
found a small bug is push a fix for it.

[commit msg]: fix requestCrumb(...) option array missing 'headers: {}' for 'options.headers = Object.assign(options.headers, { Authorization: 'Basic ' + authToken });'