### PR TITLE
Fix token auth (instead of setting headers)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,8 +59,10 @@ function requestCrumb(fs: any, request: any, url: string, crumbUrl: string, user
                 'pass': pass
             };
         } else if ( token !== undefined && token.length > 0) {
-            let authToken = new Buffer(user + ':' + token).toString('base64');
-            options.headers = Object.assign(options.headers, { Authorization: 'Basic ' + authToken });
+            options.auth = {
+                'user': user,
+                'pass': token
+            };
         }
     }
 
@@ -106,8 +108,10 @@ function validateRequest(fs: any, request: any, url: string, user: string|undefi
                         'pass': pass
                     };
                 } else if ( token !== undefined && token.length > 0) {
-                    let authToken = new Buffer(user + ':' + token).toString('base64');
-                    options.headers = Object.assign(options.headers, { Authorization: 'Basic ' + authToken });
+                    options.auth = {
+                        'user': user,
+                        'pass': token
+                    };
                 }
             }
 


### PR DESCRIPTION
Fixes #19, #27 and #30. Also makes #15 obsolete.

I noticed that token auth wasn't working and having my password in plain text isn't an option.

Seems like `Object.assign` throws the error `Cannot convert undefined or null to object` because `options.headers` wasn't defined before. But i decided, instead of setting the headers to empty object above (like #15 does), using the `options.auth` to keep it consistent.
The code for token auth previously must have been missed that part when updating to `options.auth`.

The failure grabbed from VSCode Extension Host Logs was
```
[2021-04-26 17:54:48.096] [exthost] [error] TypeError: Cannot convert undefined or null to object
	at Function.assign (<anonymous>)
	at requestCrumb (c:\Users\<user>\.vscode\extensions\janjoerke.jenkins-pipeline-linter-connector-1.2.0\out\extension.js:65:38)
	at c:\Users\<user>\.vscode\extensions\janjoerke.jenkins-pipeline-linter-connector-1.2.0\out\extension.js:36:17
	at Generator.next (<anonymous>)
	at c:\Users\<user>\.vscode\extensions\janjoerke.jenkins-pipeline-linter-connector-1.2.0\out\extension.js:7:71
	at new Promise (<anonymous>)
	at __awaiter (c:\Users\<user>\.vscode\extensions\janjoerke.jenkins-pipeline-linter-connector-1.2.0\out\extension.js:3:12)
	at c:\Users\<user>\.vscode\extensions\janjoerke.jenkins-pipeline-linter-connector-1.2.0\out\extension.js:17:104
	... (truncated here)
	at Socket.emit (events.js:315:20)
	at addChunk (_stream_readable.js:295:12)
	at readableAddChunk (_stream_readable.js:271:9)
	at Socket.Readable.push (_stream_readable.js:212:10)
	at Pipe.onStreamRead (internal/stream_base_commons.js:186:23) jenkins.pipeline.linter.connector.validate
```